### PR TITLE
Camera tweaks

### DIFF
--- a/Patches/CameraPatch.cs
+++ b/Patches/CameraPatch.cs
@@ -30,7 +30,9 @@ namespace LCThirdPerson.Patches
             var playerModel = Instance.thisPlayerModel;
 
             // Hide the visor
-            visor.gameObject.SetActive(false);
+            // visor.gameObject.SetActive(false);
+            var visorRenderers = visor.GetComponentInChildren<MeshRenderer>();
+            if (visorRenderers) visorRenderers.enabled = false;
 
             // Show the player model
             playerModel.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.On;
@@ -53,7 +55,9 @@ namespace LCThirdPerson.Patches
             var playerModel = Instance.thisPlayerModel;
 
             // Show the visor
-            visor.gameObject.SetActive(true);
+            // visor.gameObject.SetActive(true);
+            var visorRenderers = visor.GetComponentInChildren<MeshRenderer>();
+            if (visorRenderers) visorRenderers.enabled = true;
 
             // Hide the player model
             playerModel.shadowCastingMode = OriginalShadowCastingMode;

--- a/Patches/CameraPatch.cs
+++ b/Patches/CameraPatch.cs
@@ -39,7 +39,7 @@ namespace LCThirdPerson.Patches
             Instance.thisPlayerModelArms.enabled = false;
 
             // Increase the grab distance
-            Instance.grabDistance = Math.Max(Instance.grabDistance - ThirdPersonPlugin.Instance.Offset.Value.z, 5);
+            Instance.grabDistance = Math.Max(5f - ThirdPersonPlugin.Instance.Offset.Value.z, 5);
 
             // Set culling mask to see model's layer
             Instance.gameplayCamera.cullingMask = OriginalCullingMask | (1 << 23);

--- a/Patches/CameraPatch.cs
+++ b/Patches/CameraPatch.cs
@@ -161,7 +161,7 @@ namespace LCThirdPerson.Patches
             }
             else
             {
-                offset += originalTransform.transform.forward * -2f;
+                offset += originalTransform.transform.forward * ThirdPersonPlugin.Instance.Offset.Value.z;
             }
 
             // Set the camera offset

--- a/Patches/CameraPatch.cs
+++ b/Patches/CameraPatch.cs
@@ -161,7 +161,7 @@ namespace LCThirdPerson.Patches
             var offset = originalTransform.transform.right * ThirdPersonPlugin.Instance.Offset.Value.x +
                 originalTransform.transform.up * ThirdPersonPlugin.Instance.Offset.Value.y;
             var lineStart = originalTransform.transform.position;
-            var lineEnd = originalTransform.transform.position + offset + originalTransform.transform.forward * ThirdPersonPlugin.Instance.Offset.Value.z;
+            var lineEnd = originalTransform.transform.position + forwardOffset + offset + originalTransform.transform.forward * ThirdPersonPlugin.Instance.Offset.Value.z;
 
             // Check for camera collisions
             if (Physics.Linecast(lineStart, lineEnd, out RaycastHit hit, StartOfRound.Instance.collidersAndRoomMask) && !IgnoreCollision(hit.transform.name))

--- a/Patches/CameraPatch.cs
+++ b/Patches/CameraPatch.cs
@@ -146,7 +146,7 @@ namespace LCThirdPerson.Patches
             // Move camera forward/back to avoid head better
             var forwardOffset = originalTransform.up;
             forwardOffset.y = 0f;
-            forwardOffset *= 0.2f;
+            forwardOffset *= ThirdPersonPlugin.Instance.CameraLookDownOffset.Value;
 
             var gameplayCamera = Instance.gameplayCamera;
 
@@ -174,7 +174,7 @@ namespace LCThirdPerson.Patches
             }
 
             // Limit height movement by camera
-            offset.y = Math.Min(offset.y, 2f);
+            offset.y = Math.Min(offset.y, ThirdPersonPlugin.Instance.CameraMaxHeight.Value);
 
             // Set the camera offset
             gameplayCamera.transform.position = originalTransform.transform.position + forwardOffset + offset;

--- a/Patches/CameraPatch.cs
+++ b/Patches/CameraPatch.cs
@@ -139,6 +139,11 @@ namespace LCThirdPerson.Patches
                 return;
             }
 
+            // Move camera forward/back to avoid head better
+            var forwardOffset = originalTransform.up;
+            forwardOffset.y = 0f;
+            forwardOffset *= 0.2f;
+
             var gameplayCamera = Instance.gameplayCamera;
 
             // Set the placeholder rotation to match the updated gameplayCamera rotation
@@ -164,8 +169,11 @@ namespace LCThirdPerson.Patches
                 offset += originalTransform.transform.forward * ThirdPersonPlugin.Instance.Offset.Value.z;
             }
 
+            // Limit height movement by camera
+            offset.y = Math.Min(offset.y, 2f);
+
             // Set the camera offset
-            gameplayCamera.transform.position = originalTransform.transform.position + offset;
+            gameplayCamera.transform.position = originalTransform.transform.position + forwardOffset + offset;
 
             // Don't fix interact ray if on a ladder
             if (Instance.isClimbingLadder)

--- a/ThirdPersonPlugin.cs
+++ b/ThirdPersonPlugin.cs
@@ -24,6 +24,8 @@ namespace LCThirdPerson
         public ConfigEntry<bool> ShowCursor { get; set; }
         public ConfigEntry<bool> StartEnabled { get; set; }
         public ConfigEntry<Vector3> Offset { get; set; }
+        public ConfigEntry<float> CameraMaxHeight { get; set; }
+        public ConfigEntry<float> CameraLookDownOffset { get; set; }
 
         private bool tpEnabled;
         public bool Enabled { 
@@ -65,6 +67,8 @@ namespace LCThirdPerson
             ShowCursor = Config.Bind("Options", "ShowCursor", true);
             StartEnabled = Config.Bind("Options", "StartEnabled", true);
             Offset = Config.Bind("Options", "CameraOffset", new Vector3(1f, 0f, -2f));
+            CameraMaxHeight = Config.Bind("Options", "CameraMaxHeight", 1f);
+            CameraLookDownOffset = Config.Bind("Options", "CameraLookDownOffset", 0.2f);
 
             Enabled = StartEnabled.Value;
         }


### PR DESCRIPTION
Added new settings:

CameraMaxHeight - limits how high the camera can go. A workaround solution for not being able to grab items when looking down while standing.

CameraLookDownOffset - Moves the camera forwards as you look down. Vice versa, moves the camera backwards as you look up. Makes it easier to see below in front of the model when looking down. Also makes it easier to see what's above you when looking up.